### PR TITLE
Display changed nodes when after loading

### DIFF
--- a/catalog_viewer.js
+++ b/catalog_viewer.js
@@ -227,6 +227,7 @@ function addPie(diff) {
   if ($('#node .jumbotron').length === 0) {
     $('#node').html('');
   }
+  listNodes('with changes');
 }
 
 function badgeValue(n, data) {


### PR DESCRIPTION
Most people will want to see the changed nodes summary immediate after
loading a new report, so display it by default.