### PR TITLE
Load JS libraries using scheme-less URIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <link href="css/sh_style.css" rel="stylesheet" type="text/css">
     <link href="css/catalog_viewer.css" rel="stylesheet" type="text/css">
     
-    <script src="http://code.jquery.com/jquery-1.11.3.min.js" type="text/javascript"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="//code.jquery.com/jquery-1.11.3.min.js" type="text/javascript"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
     <script src="lib/d3.v3.min.js" charset="utf-8" type="text/javascript"></script>
     <script src="lib/sh_main.min.js" type="text/javascript"></script>
     <script src="lib/sh_diff.js" type="text/javascript"></script>


### PR DESCRIPTION
If the index.html is loaded via HTTP then Chrome (and probably other
browsers) won't load the jquery and bootstrap js because of mixed
content.  If we leave out the scheme then it will use http or https as
needed.