### PR TITLE
Add support for server side storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ $ docker run -ti -p 8080:80 camptocamp/puppet-catalog-diff-viewer
 
 will let you access the catalog diff viewer at `http://localhost:8080/catalog_diff`.
 
+Server Side storage
+-------------------
+
+The will automatically populate the drop-down list of available reports, if they can be read from `reportlist.json`.
+This file contains a record of the json files in `data`.
+Assuming you have
+```
+data/
+  file1.json
+  file2.json
+```
+the `reportlist.json` should have the format
+```json
+{
+  "First Report": "file1",
+  "Second Report": "file2"
+}
+```
+
 S3 storage
 ----------
 

--- a/catalog_viewer.js
+++ b/catalog_viewer.js
@@ -77,6 +77,17 @@ function loadReportData(r, data) {
   $('#crumb-report').html('<span class="glyphicon glyphicon-file" aria-hidden="true"></span> '+report_title);
 }
 
+function loadReportList() {
+  $.getJSON('reportlist.json', function(data) {
+      $("#reports-list").empty();
+      $.each( data, function( name, filename ) {
+        $("#reports-list").append('<li><a id=\"' + filename + '\" href=\"javascript:loadReport(\'' + filename + '\')\">' + name + '</a></li>');
+      });
+    }).error(function(jqXHR, textStatus, errorThrown) {
+      console.log('No report list available.');
+    });
+}
+
 function loadFile() {
   // Close collapsed if need be
   $('#navbar-collapse-menu').collapse('hide');

--- a/index.html
+++ b/index.html
@@ -184,6 +184,10 @@
         jQuery('html, body').animate({scrollTop: 0}, duration);
         return false;
       })
+
+      // try loading report list from server and update menu
+      loadReportList();
+
     });
 
     // No ajax cache


### PR DESCRIPTION
The contents of the file reportlist.json will - if present - be used to populate the drop-down menu of available reports.