### PR TITLE
Add `all_changed_nodes` to reserved words list

### DIFF
--- a/catalog_viewer.js
+++ b/catalog_viewer.js
@@ -145,7 +145,7 @@ function addPie(diff) {
   if (diff.pull_output != undefined) {
     failed = Object.keys(diff.pull_output.failed_nodes);
   }
-  var reserved = ['date', 'max_diff', 'most_changed', 'most_differences', 'total_nodes', 'total_percentage', 'with_changes', 'pull_output', 'fact_search'];
+  var reserved = ['date', 'max_diff', 'most_changed', 'most_differences', 'total_nodes', 'total_percentage', 'with_changes', 'pull_output', 'fact_search', 'all_changed_nodes'];
   var no_changes = $(all).not(with_changes).not(failed).not(reserved);
 
   diff.no_changes = [];


### PR DESCRIPTION
`all_changed_nodes` was added to the reports in
https://github.com/camptocamp/puppet-catalog-diff/pull/34

This change doesn't start using it instead of `most_differences`, but
does fix an issue with the string `all_changed_nodes` being mistaken for
the name of a host with no changes.