### PR TITLE
Fix rendering of diffs for content that can be intepreted as HTML tags

### DIFF
--- a/catalog_viewer.js
+++ b/catalog_viewer.js
@@ -750,12 +750,12 @@ function differencesAsDiff(data) {
           .on("click", $.proxy(function(k, diff_str, data) { toggleStarDiff(k, diff_str, 'diff', data) }, null, k, diff_str, data)))
       .append($('<div>', { class: 'resource-title', html: k })
           .on("click", $.proxy(function(k) { activateDiff('diff', k) }, null, k)))
-      .append($('<pre>', { class: 'sh_diff', html: diff_str })
+      .append($('<pre>', { class: 'sh_diff', text: diff_str })
           .on("click", $.proxy(function(k) { activateDiff('diff', k) }, null, k)));
 
     if (data.content_differences[k]) {
       var content_diff_str = data.content_differences[k];
-      resource.append($('<pre>', { class: 'sh_diff', html: content_diff_str }));
+      resource.append($('<pre>', { class: 'sh_diff', text: content_diff_str }));
     }
 
     html.append(resource);


### PR DESCRIPTION
When catalog-diff-viewer shows a diff that contains HTML like tags (most commonly where Puppet manages XML config) these get interpreted by the browser and result in the diff being unreadable.

The patch switches from the jQuery html() function to the text() function. The text() function includes HTML escaping and allows the diff to render as expected in the browser.